### PR TITLE
Merge Test into Main

### DIFF
--- a/.github/scripts/.package.zsh
+++ b/.github/scripts/.package.zsh
@@ -180,18 +180,13 @@ ${_usage_host:-}"
     if (( _loglevel > 1  || ${+CI} )) _tarflags="v${_tarflags}"
 
     if (( package )) {
-      if [[ ! -f ${project_root}/build_macos/installer-macos.generated.pkgproj ]] {
-        log_error 'Packages project file not found. Run the build script or the CMake build and install procedures first.'
+      if [[ ! -f ${project_root}/release/${config}/${product_name}.pkg ]] {
+        log_error 'Installer Package not found. Run the build script or the CMake build and install procedures first.'
         return 2
       }
 
-      check_packages
-
       log_group "Packaging ${product_name}..."
       pushd ${project_root}
-      packagesbuild \
-        --build-folder ${project_root}/release/${config} \
-        ${project_root}/build_macos/installer-macos.generated.pkgproj
 
       if (( codesign )) {
         read_codesign_installer

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -130,7 +130,7 @@ jobs:
           codesignIdent: ${{ steps.codesign.outputs.codesignIdent }}
           installerIdent: ${{ steps.codesign.outputs.installerIdent }}
           codesignTeam: ${{ steps.codesign.outputs.codesignTeam }}
-          notarize: 'false'
+          notarize: ${{ fromJSON(needs.check-event.outputs.notarize) && fromJSON(steps.codesign.outputs.haveNotarizationUser) }}
           codesignUser: ${{ secrets.MACOS_NOTARIZATION_USERNAME }}
           codesignPass: ${{ secrets.MACOS_NOTARIZATION_PASSWORD }}
 

--- a/.github/workflows/pr-pull.yaml
+++ b/.github/workflows/pr-pull.yaml
@@ -6,7 +6,7 @@ on:
     paths-ignore:
       - '**.md'
     branches: [master, main]
-    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+    types: [ opened, synchronize, reopened ]
 permissions:
   contents: read
 concurrency:

--- a/buildspec.json
+++ b/buildspec.json
@@ -45,7 +45,7 @@
         }
     },
     "name": "pixel-art",
-    "version": "0.0.2",
+    "version": "0.0.4",
     "author": "John DSPStanky Stankiewicz",
     "website": "https://github.com/dspstanky/pixel-art",
     "email": "dspstanky@gmail.com",

--- a/cmake/macos/helpers.cmake
+++ b/cmake/macos/helpers.cmake
@@ -79,7 +79,9 @@ function(set_target_properties_plugin target)
     CONFIGURATIONS Release
     DESTINATION .
     OPTIONAL)
-  configure_file(cmake/macos/resources/create-package.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/create-package.cmake")
+
+  configure_file(cmake/macos/resources/distribution.in "${CMAKE_CURRENT_BINARY_DIR}/distribution" @ONLY)
+  configure_file(cmake/macos/resources/create-package.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/create-package.cmake" @ONLY)
   install(SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/create-package.cmake")
 endfunction()
 

--- a/cmake/macos/resources/create-package.cmake.in
+++ b/cmake/macos/resources/create-package.cmake.in
@@ -1,7 +1,35 @@
-set(CMAKE_PROJECT_NAME ${CMAKE_PROJECT_NAME})
-set(CMAKE_PROJECT_VERSION ${CMAKE_PROJECT_VERSION})
-set(MACOS_BUNDLEID ${MACOS_BUNDLEID})
-set(UUID_PACKAGE ${UUID_PACKAGE})
-set(UUID_INSTALLER ${UUID_INSTALLER})
-configure_file(cmake/macos/resources/installer-macos.pkgproj.in
-  "${CMAKE_CURRENT_BINARY_DIR}/installer-macos.generated.pkgproj")
+make_directory("$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/package/Library/Application Support/obs-studio/plugins")
+
+if(EXISTS "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.plugin" AND NOT IS_SYMLINK "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.plugin")
+  file(INSTALL DESTINATION "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/package/Library/Application Support/obs-studio/plugins"
+    TYPE DIRECTORY FILES "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.plugin" USE_SOURCE_PERMISSIONS)
+
+  if(CMAKE_INSTALL_CONFIG_NAME MATCHES "^([Rr][Ee][Ll][Ee][Aa][Ss][Ee])$" OR CMAKE_INSTALL_CONFIG_NAME MATCHES "^([Mm][Ii][Nn][Ss][Ii][Zz][Ee][Rr][Ee][Ll])$")
+    if(EXISTS "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.plugin.dSYM" AND NOT IS_SYMLINK "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.plugin.dSYM")
+      file(INSTALL DESTINATION "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/package/Library/Application Support/obs-studio/plugins" TYPE DIRECTORY FILES "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.plugin.dSYM" USE_SOURCE_PERMISSIONS)
+    endif()
+  endif()
+endif()
+
+make_directory("$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/temp")
+
+execute_process(
+  COMMAND /usr/bin/pkgbuild
+    --identifier '@MACOS_BUNDLEID@'
+    --version '@CMAKE_PROJECT_VERSION@'
+    --root "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/package"
+    "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/temp/@CMAKE_PROJECT_NAME@.pkg"
+    COMMAND_ERROR_IS_FATAL ANY
+  )
+
+execute_process(
+  COMMAND /usr/bin/productbuild
+    --distribution "@CMAKE_CURRENT_BINARY_DIR@/distribution"
+    --package-path "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/temp"
+    "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.pkg"
+    COMMAND_ERROR_IS_FATAL ANY)
+
+if(EXISTS "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.pkg")
+  file(REMOVE_RECURSE "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/temp")
+  file(REMOVE_RECURSE "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/package")
+endif()

--- a/cmake/macos/resources/distribution.in
+++ b/cmake/macos/resources/distribution.in
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<installer-gui-script minSpecVersion="1.0">
+    <options
+        rootVolumeOnly="true"
+        hostArchitectures="arm64,x86_64"
+        customize="never"
+        allow-external-scripts="no" />
+    <domains enable_currentUserHome="true" enable_anywhere="false" enable_localSystem="false" />
+    <title>@CMAKE_PROJECT_NAME@</title>
+    <choices-outline>
+        <line choice="obs-plugin" />
+    </choices-outline>
+    <choice id="obs-plugin" title="@CMAKE_PROJECT_NAME@" description="">
+        <pkg-ref id="@MACOS_BUNDLEID@" />
+    </choice>
+    <pkg-ref id="@MACOS_BUNDLEID@" version="@CMAKE_PROJECT_VERSION@">#@CMAKE_PROJECT_NAME@.pkg</pkg-ref>
+    <installation-check script="installCheck();" />
+    <script>
+        function installCheck() {
+            var macOSVersion = system.version.ProductVersion
+
+            if (system.compareVersions(macOSVersion, '@CMAKE_OSX_DEPLOYMENT_TARGET@') == -1) {
+                my.result.title = system.localizedStandardStringWithFormat(
+                                    'InstallationCheckError',
+                                    system.localizedString('DISTRIBUTION_TITLE')
+                                  );
+                my.result.message = ' ';
+                my.result.type = 'Fatal';
+                return false;
+            }
+        }
+    </script>
+
+</installer-gui-script>


### PR DESCRIPTION
## Description
  After a long day of messing with git, finally ready to merge in [OBS-PluginTemplate Pull Request 92](https://github.com/obsproject/obs-plugintemplate/pull/92), which removes the dependency for Packages.app and instead builds MacOS plugin using native tools.
## Motivation
  If I don't merge in this code change from obs-mastertemplate, will not be able to create a release containing the newest changes to fix issue #2 . The Package.app dependency had a recent undocumented change that altered the checksum, activating a few OBS failsafes. With these activated, a build for MacOS would not complete, preventing a release from being created.
## Credit
  This is code written by [PatTheMav](https://github.com/PatTheMav) for OBS-PluginTemplate. Code contained in pixel-art.c and pixel_art.effect is my own code.